### PR TITLE
feat: 添加网络磁盘扫描进度提示 (#46)

### DIFF
--- a/src/main/ipc/library/scan.js
+++ b/src/main/ipc/library/scan.js
@@ -391,7 +391,7 @@ function registerLibraryScanIpcHandlers(
 
             const win = getMainWindow();
             if (win && tracks.length > 0) {
-                win.webContents.send('library:scanProgress', {
+                win.webContents.send('library:scan-progress', {
                     current: i + batch.length,
                     total: files.length,
                     tracks: tracks.length
@@ -502,7 +502,7 @@ function registerLibraryScanIpcHandlers(
 
             const win = getMainWindow();
             if (win && tracks.length > 0) {
-                win.webContents.send('library:scanProgress', {
+                win.webContents.send('library:scan-progress', {
                     current: i + batch.length,
                     total: files.length,
                     tracks: tracks.length

--- a/src/main/ipc/library/scan.js
+++ b/src/main/ipc/library/scan.js
@@ -391,7 +391,7 @@ function registerLibraryScanIpcHandlers(
 
             const win = getMainWindow();
             if (win && tracks.length > 0) {
-                win.webContents.send('library:scan-progress', {
+                win.webContents.send('library:scanProgress', {
                     current: i + batch.length,
                     total: files.length,
                     tracks: tracks.length
@@ -502,7 +502,7 @@ function registerLibraryScanIpcHandlers(
 
             const win = getMainWindow();
             if (win && tracks.length > 0) {
-                win.webContents.send('library:scan-progress', {
+                win.webContents.send('library:scanProgress', {
                     current: i + batch.length,
                     total: files.length,
                     tracks: tracks.length

--- a/src/renderer/src/js/components/component/NetworkDiskModal.js
+++ b/src/renderer/src/js/components/component/NetworkDiskModal.js
@@ -378,17 +378,74 @@ class NetworkDiskModal extends Component {
     // 扫描网络磁盘
     async scanNetworkDrive(driveId) {
         try {
-            this.showNotification('正在扫描网络磁盘...', 'info');
+            // 禁用扫描按钮并显示进度提示
+            this.showScanTip(driveId);
+
+            // 监听扫描进度
+            const onProgress = (event, progress) => {
+                this.updateScanTip(driveId, progress);
+            };
+            const removeListener = window.electronAPI.library.onScanProgress(onProgress);
 
             // 使用API层的统一方法
             const success = await api.scanNetworkDrive(driveId, '/');
+
+            removeListener();
+            this.hideScanTip(driveId);
+
             if (success) {
                 this.showNotification('网络磁盘扫描完成', 'success');
             } else {
                 this.showNotification('网络磁盘扫描失败', 'error');
             }
         } catch (error) {
+            this.hideScanTip(driveId);
             this.showNotification(`扫描失败: ${error.message}`, 'error');
+        }
+    }
+
+    showScanTip(driveId) {
+        const btn = this.mountedDrivesList?.querySelector(`.scan-drive-btn[data-drive-id="${driveId}"]`);
+        if (btn) {
+            btn.disabled = true;
+            btn.textContent = '扫描中...';
+        }
+
+        const driveItem = this.mountedDrivesList?.querySelector(`.mounted-drive-item[data-drive-id="${driveId}"]`);
+        if (!driveItem) return;
+
+        const tip = document.createElement('div');
+        tip.className = 'scan-tip';
+        tip.dataset.scanTipDriveId = driveId;
+        tip.innerHTML = `
+            <div class="scan-tip-bar">
+                <div class="scan-tip-fill" data-scan-fill="${driveId}"></div>
+            </div>
+            <p class="scan-tip-text" data-scan-text="${driveId}">⏳ 正在扫描网络磁盘...</p>
+        `;
+        driveItem.appendChild(tip);
+    }
+
+    updateScanTip(driveId, progress) {
+        const fill = this.mountedDrivesList?.querySelector(`[data-scan-fill="${driveId}"]`);
+        const text = this.mountedDrivesList?.querySelector(`[data-scan-text="${driveId}"]`);
+
+        if (fill && text) {
+            const percent = progress.total > 0 ?
+                (progress.current / progress.total) * 100 : 0;
+            fill.style.width = `${percent}%`;
+            text.textContent = `⏳ 扫描中: ${progress.current}/${progress.total} (${progress.tracks} 首歌曲)`;
+        }
+    }
+
+    hideScanTip(driveId) {
+        const tip = this.mountedDrivesList?.querySelector(`[data-scan-tip-drive-id="${driveId}"]`);
+        if (tip) tip.remove();
+
+        const btn = this.mountedDrivesList?.querySelector(`.scan-drive-btn[data-drive-id="${driveId}"]`);
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = '扫描';
         }
     }
 

--- a/src/renderer/src/js/components/component/NetworkDiskModal.js
+++ b/src/renderer/src/js/components/component/NetworkDiskModal.js
@@ -377,21 +377,17 @@ class NetworkDiskModal extends Component {
 
     // 扫描网络磁盘
     async scanNetworkDrive(driveId) {
+        // 禁用扫描按钮并显示进度提示
+        this.showScanTip(driveId);
+
+        // 监听扫描进度
+        const removeListener = window.electronAPI.library.onScanProgress((event, progress) => {
+            this.updateScanTip(driveId, progress);
+        });
+
         try {
-            // 禁用扫描按钮并显示进度提示
-            this.showScanTip(driveId);
-
-            // 监听扫描进度
-            const onProgress = (event, progress) => {
-                this.updateScanTip(driveId, progress);
-            };
-            const removeListener = window.electronAPI.library.onScanProgress(onProgress);
-
             // 使用API层的统一方法
             const success = await api.scanNetworkDrive(driveId, '/');
-
-            removeListener();
-            this.hideScanTip(driveId);
 
             if (success) {
                 this.showNotification('网络磁盘扫描完成', 'success');
@@ -399,8 +395,10 @@ class NetworkDiskModal extends Component {
                 this.showNotification('网络磁盘扫描失败', 'error');
             }
         } catch (error) {
-            this.hideScanTip(driveId);
             this.showNotification(`扫描失败: ${error.message}`, 'error');
+        } finally {
+            removeListener();
+            this.hideScanTip(driveId);
         }
     }
 
@@ -434,7 +432,7 @@ class NetworkDiskModal extends Component {
             const percent = progress.total > 0 ?
                 (progress.current / progress.total) * 100 : 0;
             fill.style.width = `${percent}%`;
-            text.textContent = `⏳ 扫描中: ${progress.current}/${progress.total} (${progress.tracks} 首歌曲)`;
+            text.textContent = `⏳ 扫描中: ${progress.current}/${progress.total}`;
         }
     }
 

--- a/src/renderer/src/js/components/component/NetworkDriveDetailPage.js
+++ b/src/renderer/src/js/components/component/NetworkDriveDetailPage.js
@@ -257,20 +257,75 @@ class NetworkDriveDetailPage extends Component {
 
     async scanDrive() {
         try {
-            app.showInfo('开始扫描网络磁盘...');
+            // 显示扫描进度提示
+            this.showScanTip();
+
+            // 监听扫描进度
+            const onProgress = (event, progress) => {
+                this.updateScanTip(progress);
+            };
+            const removeListener = window.electronAPI.library.onScanProgress(onProgress);
+
             const result = await window.electronAPI.library.scanNetworkDrive(this.currentDrive.id, '/');
 
+            // 移除进度监听
+            removeListener();
+
             if (result) {
+                this.hideScanTip();
                 await this.loadDriveTracks();
                 this.render();
                 app.showInfo(`扫描完成，找到 ${this.tracks.length} 首歌曲`);
             } else {
+                this.hideScanTip();
                 app.showError('扫描失败，请检查网络连接');
             }
         } catch (error) {
             console.error('❌ NetworkDriveDetailPage: 扫描失败', error);
+            this.hideScanTip();
             app.showError('扫描失败，请重试');
         }
+    }
+
+    showScanTip() {
+        // 禁用扫描按钮防止重复点击
+        const scanBtn = this.container.querySelector('#scan-drive-btn');
+        if (scanBtn) scanBtn.disabled = true;
+
+        // 在操作按钮区域下方插入进度提示
+        const actionsEl = this.container.querySelector('.drive-actions');
+        if (!actionsEl) return;
+
+        const tip = document.createElement('div');
+        tip.id = 'scan-tip';
+        tip.className = 'scan-tip';
+        tip.innerHTML = `
+            <div class="scan-tip-bar">
+                <div class="scan-tip-fill" id="scan-tip-fill"></div>
+            </div>
+            <p class="scan-tip-text" id="scan-tip-text">⏳ 正在扫描网络磁盘...</p>
+        `;
+        actionsEl.parentNode.insertBefore(tip, actionsEl.nextSibling);
+    }
+
+    updateScanTip(progress) {
+        const fill = document.getElementById('scan-tip-fill');
+        const text = document.getElementById('scan-tip-text');
+
+        if (fill && text) {
+            const percent = progress.total > 0 ?
+                (progress.current / progress.total) * 100 : 0;
+            fill.style.width = `${percent}%`;
+            text.textContent = `⏳ 扫描中: ${progress.current}/${progress.total} (${progress.tracks} 首歌曲)`;
+        }
+    }
+
+    hideScanTip() {
+        const tip = document.getElementById('scan-tip');
+        if (tip) tip.remove();
+
+        const scanBtn = this.container.querySelector('#scan-drive-btn');
+        if (scanBtn) scanBtn.disabled = false;
     }
 
     async removeDrive() {

--- a/src/renderer/src/js/components/component/NetworkDriveDetailPage.js
+++ b/src/renderer/src/js/components/component/NetworkDriveDetailPage.js
@@ -256,34 +256,30 @@ class NetworkDriveDetailPage extends Component {
     }
 
     async scanDrive() {
+        // 显示扫描进度提示
+        this.showScanTip();
+
+        // 监听扫描进度
+        const removeListener = window.electronAPI.library.onScanProgress((event, progress) => {
+            this.updateScanTip(progress);
+        });
+
         try {
-            // 显示扫描进度提示
-            this.showScanTip();
-
-            // 监听扫描进度
-            const onProgress = (event, progress) => {
-                this.updateScanTip(progress);
-            };
-            const removeListener = window.electronAPI.library.onScanProgress(onProgress);
-
             const result = await window.electronAPI.library.scanNetworkDrive(this.currentDrive.id, '/');
 
-            // 移除进度监听
-            removeListener();
-
             if (result) {
-                this.hideScanTip();
                 await this.loadDriveTracks();
                 this.render();
                 app.showInfo(`扫描完成，找到 ${this.tracks.length} 首歌曲`);
             } else {
-                this.hideScanTip();
                 app.showError('扫描失败，请检查网络连接');
             }
         } catch (error) {
             console.error('❌ NetworkDriveDetailPage: 扫描失败', error);
-            this.hideScanTip();
             app.showError('扫描失败，请重试');
+        } finally {
+            removeListener();
+            this.hideScanTip();
         }
     }
 
@@ -316,7 +312,7 @@ class NetworkDriveDetailPage extends Component {
             const percent = progress.total > 0 ?
                 (progress.current / progress.total) * 100 : 0;
             fill.style.width = `${percent}%`;
-            text.textContent = `⏳ 扫描中: ${progress.current}/${progress.total} (${progress.tracks} 首歌曲)`;
+            text.textContent = `⏳ 扫描中: ${progress.current}/${progress.total}`;
         }
     }
 

--- a/src/renderer/src/styles/main.scss
+++ b/src/renderer/src/styles/main.scss
@@ -5655,6 +5655,33 @@ a {
   }
 }
 
+// Network drive scan tip
+.scan-tip {
+  padding: var(--spacing-md) var(--spacing-lg);
+}
+
+.scan-tip-bar {
+  height: 4px;
+  background: var(--color-secondary-bg);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: var(--spacing-xs);
+
+  .scan-tip-fill {
+    height: 100%;
+    background: var(--color-primary);
+    border-radius: 2px;
+    transition: width 0.3s ease;
+    width: 0%;
+  }
+}
+
+.scan-tip-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
 // Empty State
 .empty-state {
   display: flex;


### PR DESCRIPTION
你好👋，我准备为 #46  提交一个 PR。

用户点击"扫描"按钮扫描网络磁盘音乐文件时，没有任何进度反馈，无法感知扫描是否在进行。

## 改动内容

### 1. 修复进度事件名不一致

`scan.js` 中的进度事件名 `library:scan-progress` 与 `preload.ts` 监听的 `library:scanProgress` 不一致，导致前端无法接收进度事件。统一为 `library:scanProgress`。

### 2. 添加扫描进度提示

在网络磁盘详情页（`NetworkDriveDetailPage`）和设置页 Modal（`NetworkDiskModal`）的扫描按钮处添加轻量进度条 tip：

- 扫描开始时在按钮下方显示进度条和文字
- 实时更新：`扫描中: 已处理文件数/总文件数 (已识别歌曲数)`
- 扫描完成/失败后自动移除进度提示
- 扫描期间禁用按钮防止重复点击

效果如下：
<img width="1440" height="902" alt="设置" src="https://github.com/user-attachments/assets/e8291473-9c6a-4035-a622-92c2bc608928" />
<img width="1440" height="902" alt="外部" src="https://github.com/user-attachments/assets/af49fea2-3abd-4e84-9020-74b55130730d" />
