### PR TITLE
修复了从文件夹添加歌曲到歌单，侧边栏歌单UI的歌曲数量不会更新的问题

### DIFF
--- a/src/renderer/src/js/components/component/PlaylistDetailPage.js
+++ b/src/renderer/src/js/components/component/PlaylistDetailPage.js
@@ -609,6 +609,7 @@ class PlaylistDetailPage extends Component {
                 }
                 app.showSuccess(message);
                 await this.loadPlaylistTracks();
+                this.emit('playlistUpdated', this.currentPlaylist);
             } else {
                 app.showError(result.error || '添加歌曲到歌单失败');
             }


### PR DESCRIPTION
修复：在添加歌曲后，手动触发 playlistUpdated 歌单更新事件