### PR TITLE
修改侧边栏歌单UI布局以展示更多文字，补充了编辑歌单描述的功能

### DIFF
--- a/src/main/controllers/LibraryController.ts
+++ b/src/main/controllers/LibraryController.ts
@@ -178,13 +178,13 @@ export class LibraryController extends BaseController {
     }
 
     @IpcHandle('library:renamePlaylist')
-    async renamePlaylist(playlistId: string, newName: string): Promise<{
+    async renamePlaylist(playlistId: string, newName: string, description = ''): Promise<{
         success: boolean;
         playlist?: any;
         error?: string
     }> {
         try {
-            const playlist = this.libraryCacheManager.renamePlaylist(playlistId, newName);
+            const playlist = this.libraryCacheManager.renamePlaylist(playlistId, newName, description);
             await this.libraryCacheManager.saveCache();
             return {success: true, playlist};
         } catch (error: any) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -231,7 +231,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         createPlaylist: (name: string, description: string) => ipcRenderer.invoke('library:createPlaylist', name, description),
         getPlaylistDetail: (playlistId: string) => ipcRenderer.invoke('library:getPlaylistDetail', playlistId),
         deletePlaylist: (playlistId: string) => ipcRenderer.invoke('library:deletePlaylist', playlistId),
-        renamePlaylist: (playlistId: string, newName: string) => ipcRenderer.invoke('library:renamePlaylist', playlistId, newName),
+        renamePlaylist: (playlistId: string, newName: string, description = '') => ipcRenderer.invoke('library:renamePlaylist', playlistId, newName, description),
         addToPlaylist: (playlistId: string, trackIds: string[]) => ipcRenderer.invoke('library:addToPlaylist', playlistId, trackIds),
         removeFromPlaylist: (playlistId: string, trackIds: string[]) => ipcRenderer.invoke('library:removeFromPlaylist', playlistId, trackIds),
         cleanupPlaylists: () => ipcRenderer.invoke('library:cleanupPlaylists'),

--- a/src/main/services/library/LibraryCacheManager.ts
+++ b/src/main/services/library/LibraryCacheManager.ts
@@ -494,13 +494,14 @@ export class LibraryCacheManager {
         return true;
     }
 
-    renamePlaylist(playlistId: string, newName: string): Playlist {
+    renamePlaylist(playlistId: string, newName: string, description = ''): Playlist {
         if (!newName?.trim()) throw new Error('歌单名称不能为空');
         const playlist = this.getPlaylistById(playlistId);
         if (!playlist) throw new Error('歌单不存在');
         if (this.cache.playlists.find(p => p.id !== playlistId && p.name === newName.trim())) throw new Error('歌单名称已存在');
         const oldName = playlist.name;
         playlist.name = newName.trim();
+        playlist.description = description.trim();
         playlist.updatedAt = Date.now();
         console.log(`✏️ LibraryCacheManager: 重命名歌单 - ${oldName} -> ${playlist.name}`);
         return playlist;

--- a/src/renderer/src/index.html
+++ b/src/renderer/src/index.html
@@ -441,6 +441,10 @@
                         <input type="text" id="rename-playlist-input" class="form-input" placeholder="请输入新的歌单名称" maxlength="50">
                         <div class="form-error" id="rename-playlist-error" style="display: none;"></div>
                     </div>
+                    <div class="form-group">
+                        <label for="rename-playlist-description-input" class="form-label">歌单描述（可选）</label>
+                        <textarea id="rename-playlist-description-input" class="form-textarea" placeholder="请输入歌单描述" maxlength="200" rows="3"></textarea>
+                    </div>
                 </div>
                 <div class="modal-footer">
                     <button class="btn btn-secondary" id="rename-playlist-cancel">取消</button>

--- a/src/renderer/src/js/components/dialogs/RenamePlaylistDialog.js
+++ b/src/renderer/src/js/components/dialogs/RenamePlaylistDialog.js
@@ -23,6 +23,7 @@ class RenamePlaylistDialog extends Component {
         this.currentPlaylist = playlist;
         this.overlay.style.display = 'flex';
         this.nameInput.value = playlist.name;
+        this.descriptionInput.value = playlist.description || '';
         this.hideError();
         this.validateInput();
 
@@ -52,6 +53,7 @@ class RenamePlaylistDialog extends Component {
         this.cancelBtn = document.getElementById('rename-playlist-cancel');
         this.confirmBtn = document.getElementById('rename-playlist-confirm');
         this.nameInput = document.getElementById('rename-playlist-input');
+        this.descriptionInput = document.getElementById('rename-playlist-description-input');
         this.errorElement = document.getElementById('rename-playlist-error');
     }
 
@@ -60,6 +62,7 @@ class RenamePlaylistDialog extends Component {
         this.addEventListenerManaged(this.cancelBtn, 'click', () => this.hide());
         this.addEventListenerManaged(this.confirmBtn, 'click', () => this.renamePlaylist());
         this.addEventListenerManaged(this.nameInput, 'input', () => this.validateInput());
+        this.addEventListenerManaged(this.descriptionInput, 'input', () => this.validateInput());
         this.addEventListenerManaged(this.nameInput, 'keydown', (e) => {
             if (e.key === 'Enter' && !this.confirmBtn.disabled) {
                 this.renamePlaylist();
@@ -82,15 +85,19 @@ class RenamePlaylistDialog extends Component {
 
     validateInput() {
         const name = this.nameInput.value.trim();
-        const isValid = name.length > 0 && name.length <= 50 && name !== this.currentPlaylist?.name;
+        const description = this.descriptionInput.value.trim();
+        const hasChanges = name !== this.currentPlaylist?.name || description !== (this.currentPlaylist?.description || '');
+        const isValid = name.length > 0 && name.length <= 50 && description.length <= 200 && hasChanges;
         this.confirmBtn.disabled = !isValid;
 
         if (name.length === 0) {
             this.showError('歌单名称不能为空');
         } else if (name.length > 50) {
             this.showError('歌单名称不能超过50个字符');
-        } else if (name === this.currentPlaylist?.name) {
-            this.showError('新名称与当前名称相同');
+        } else if (description.length > 200) {
+            this.showError('歌单描述不能超过200个字符');
+        } else if (!hasChanges) {
+            this.showError('歌单名称和描述均未修改');
         } else {
             this.hideError();
         }
@@ -112,11 +119,12 @@ class RenamePlaylistDialog extends Component {
         }
 
         const newName = this.nameInput.value.trim();
+        const description = this.descriptionInput.value.trim();
 
         try {
             this.confirmBtn.disabled = true;
             this.confirmBtn.textContent = '重命名中...';
-            const result = await window.electronAPI.library.renamePlaylist(this.currentPlaylist.id, newName);
+            const result = await window.electronAPI.library.renamePlaylist(this.currentPlaylist.id, newName, description);
 
             if (result.success) {
                 // 触发重命名成功事件

--- a/src/renderer/src/styles/main.scss
+++ b/src/renderer/src/styles/main.scss
@@ -736,8 +736,8 @@ a {
 }
 
 .sidebar-content {
-  padding: var(--spacing-lg);
-  padding-top: calc(var(--spacing-lg) + 48px); // 为切换按钮留出空间
+  padding: var(--spacing-md);
+  padding-top: calc(var(--spacing-md) + 48px); // 为切换按钮留出空间
   transition: all var(--transition-normal);
 }
 
@@ -2331,7 +2331,7 @@ a {
 .playlist-sidebar-item {
   display: flex;
   align-items: center;
-  padding: var(--spacing-xs) var(--spacing-md); // 减小垂直内边距，使歌单列表更紧凑
+  padding: var(--spacing-xs) var(--spacing-sm); // 减小垂直内边距，使歌单列表更紧凑
   color: var(--color-text-secondary);
   text-decoration: none;
   border-radius: var(--radius-md);
@@ -2341,11 +2341,11 @@ a {
   margin-bottom: 2px; // 添加小间距分隔歌单项
 
   &:hover {
-    background: var(--color-bg-hover);
+    background: var(--color-hover);
     color: var(--color-text);
 
     .sidebar-playlist-actions {
-      opacity: 1;
+      display: flex;
     }
   }
 
@@ -2367,7 +2367,7 @@ a {
   .sidebar-icon {
     width: 18px;
     height: 18px;
-    margin-right: var(--spacing-md);
+    margin-right: var(--spacing-sm);
     fill: var(--color-text-secondary);
     transition: fill var(--transition-fast);
   }
@@ -2393,17 +2393,21 @@ a {
 
   // 侧边栏歌单操作按钮区域 - 独立样式避免与歌单详情页面冲突
   .sidebar-playlist-actions {
-    opacity: 0;
-    display: flex;
+    position: absolute;
+    right: 2px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: none;
     align-items: center;
     gap: 2px; // 减小按钮间距，使布局更紧凑
-    margin-left: var(--spacing-xs); // 减小左边距
-    flex-shrink: 0; // 防止操作按钮被压缩
-    transition: opacity var(--transition-fast);
+    padding: 2px 4px;
+    background: var(--color-hover);
+    border-radius: var(--radius-sm);
+    z-index: 1;
   }
 
   .sidebar-playlist-action-btn {
-    background: none;
+    background: var(--color-hover);
     border: none;
     cursor: pointer;
     padding: 4px; // 使用固定像素值确保一致的按钮尺寸
@@ -2416,7 +2420,7 @@ a {
     height: 24px; // 固定高度确保对齐
 
     &:hover {
-      background: rgba(var(--color-text-rgb), 0.1); // 使用主题色变量
+      background: var(--color-hover);
     }
 
     .icon {

--- a/src/renderer/src/styles/main.scss
+++ b/src/renderer/src/styles/main.scss
@@ -2345,7 +2345,9 @@ a {
     color: var(--color-text);
 
     .sidebar-playlist-actions {
-      display: flex;
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
     }
   }
 
@@ -2397,17 +2399,24 @@ a {
     right: 2px;
     top: 50%;
     transform: translateY(-50%);
-    display: none;
+    display: flex;
     align-items: center;
     gap: 2px; // 减小按钮间距，使布局更紧凑
     padding: 2px 4px;
-    background: var(--color-hover);
+    background: inherit;
     border-radius: var(--radius-sm);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
     z-index: 1;
+    transition:
+      opacity var(--transition-fast),
+      visibility var(--transition-fast),
+      background-color var(--transition-fast);
   }
 
   .sidebar-playlist-action-btn {
-    background: var(--color-hover);
+    background: inherit;
     border: none;
     cursor: pointer;
     padding: 4px; // 使用固定像素值确保一致的按钮尺寸


### PR DESCRIPTION

现有的侧边栏歌单留给歌单标题的空间过小，仅能容纳两个中文字符或四个英文字母，如图所示，在需要折叠的情况下，展示出来的只有一个汉字或两个字母，个人感觉不方便查看，这个主要是两个原因导致：侧边栏元素两侧留的padding太大；两个按钮不显示的时候也占据了空间

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/93d7175b-29ba-4680-bbd8-2927194c560f" />

所以做了以下两个改动：
- 缩小了侧边栏元素两侧留的padding；
- 把两个按钮做成绝对定位，不占据空间，鼠标悬停时显示并覆盖下方文字
效果预览：
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/7fbdddc4-86fc-4945-a1c8-76adc589b815" />

考虑到后续可能会加入更多歌单的操作功能（例如添加至播放列表，添加至其他歌单），个人建议把操作功能放到右键菜单或者展开菜单里，去除现有的按钮

另外，新建歌单时可以添加歌单描述，但是编辑时没有提供编辑描述的功能，这可能是bug，也一并修改了，UI与新建歌单的窗口一致